### PR TITLE
exit 1 on diff, as well as missing

### DIFF
--- a/fontquery/htmlformatter.py
+++ b/fontquery/htmlformatter.py
@@ -567,7 +567,7 @@ def generate_diff(renderer: DataRenderer, title: str, data: dict[str, Any],
     renderer.imagedifftype = diffdata['pattern']
 
     yield from renderer.render_diff(langdata, missing_a, missing_b, langdiffdata)
-    yield True if not missing_a and not missing_b else False
+    yield True if not missing_a and not missing_b and not langdiffdata else False
 
 def run(mode, in1, in2, out, renderer, title):
     data = None


### PR DESCRIPTION
25bde9c made us exit 1 if something was outright missing, but not if there was a diff. So we still exit 0 if a font is present but wrong. This makes us also exit 1 if there's a diff.