### PR TITLE
traceback when redirect output: fontquery-diff --loose-comparison 44 > a; Use shutil.get_terminal_size()

### DIFF
--- a/fontquery/htmlformatter.py
+++ b/fontquery/htmlformatter.py
@@ -30,6 +30,7 @@ import json
 import os
 import re
 import sys
+import shutil
 from typing import Any, Dict, Iterator
 NO_MARKDOWN = False
 try:
@@ -414,7 +415,7 @@ class TextRenderer(DataRenderer):
     def format_line(cls, column: list[ColoredText]) -> Iterator[str]:
         ll = []
         retval = ''
-        colsize = int(os.get_terminal_size().columns / len(column))
+        colsize = int(shutil.get_terminal_size().columns / len(column))
         colsize = 15 if colsize <= 15 else colsize
         for i, s in enumerate(column):
             n = len(s)


### PR DESCRIPTION
## Summary
Replace `os.get_terminal_size()` with `shutil.get_terminal_size()` to provide fallback values when running in non-terminal environments.

## Problem
The current code uses `os.get_terminal_size()` which raises an `OSError` when stdout is not connected to a terminal. 
### Steps to Reproduce:
```fontquery-diff --loose-comparison 44 > /tmp/a```
or
```fontquery-diff --loose-comparison 44 | fpaste```

## Solution
`shutil.get_terminal_size()` provides sensible default values (80 columns × 24 lines) when the terminal size cannot be determined, making the code more robust and preventing crashes in non-interactive environments.

## Changes
- Added `import shutil` to the imports section
- Changed `os.get_terminal_size()` to `shutil.get_terminal_size()` in the `TextRenderer.format_line()` method (line 418)


🤖 Generated with [Claude Code](https://claude.com/claude-code)